### PR TITLE
Add Repository field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "foundation-libsass-template",
   "version": "0.0.1",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/zurb/foundation-libsass-template.git"
+  },
   "devDependencies": {
     "node-sass": "~0.7.0",
     "grunt": "~0.4.1",


### PR DESCRIPTION
Fixes a minor warning that appears when creating a project from the cli command.