### PR TITLE
Update devDependencies and enable sourceMap

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -8,11 +8,12 @@ module.exports = function(grunt) {
       },
       dist: {
         options: {
-          outputStyle: 'compressed'
+          outputStyle: 'compressed',
+          sourceMap: true,
         },
         files: {
           'css/app.css': 'scss/app.scss'
-        }        
+        }
       }
     },
 

--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "name": "foundation-libsass-template",
   "version": "0.0.1",
   "devDependencies": {
-    "node-sass": "~0.7.0",
-    "grunt": "~0.4.1",
-    "grunt-contrib-watch": "~0.5.3",
-    "grunt-sass": "~0.8.0"
+    "node-sass": "~0.8.4",
+    "grunt": "~0.4.4",
+    "grunt-contrib-watch": "~0.6.1",
+    "grunt-sass": "~0.12.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "foundation-libsass-template",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "devDependencies": {
     "node-sass": "~0.8.4",
     "grunt": "~0.4.4",


### PR DESCRIPTION
In more recent versions `grunt-sass` supports generating source maps, which is very useful to have enabled by default.