### PR TITLE
Fixed typo in twitter handle, should be zurbfoundation

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
               <p><a href="http://github.com/zurb/foundation">Foundation on Github</a><br />Latest code, issue reports, feature requests and more.</p>
             </div>
             <div class="large-4 medium-4 columns">
-              <p><a href="http://twitter.com/foundationzurb">@foundationzurb</a><br />Ping us on Twitter if you have questions. If you build something with this we'd love to see it (and send you a totally boss sticker).</p>
+              <p><a href="http://twitter.com/zurbfoundation">@zurbfoundation</a><br />Ping us on Twitter if you have questions. If you build something with this we'd love to see it (and send you a totally boss sticker).</p>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Twitter handle is incorrect in the demo app. It's loaded when you use the foundation cli, links to the wrong twitter user.