### PR TITLE
Libsass 3 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "name": "foundation-libsass-template",
   "version": "0.0.1",
   "devDependencies": {
-    "node-sass": "~0.9.3",
-    "grunt": "~0.4.1",
-    "grunt-contrib-watch": "~0.5.3",
-    "grunt-sass": "~0.8.1"
+    "node-sass": "~1.2.3",
+    "grunt": "~0.4.5",
+    "grunt-contrib-watch": "~0.6.1",
+    "grunt-sass": "~0.17.0"
   }
 }


### PR DESCRIPTION
This updates the `package.json` to use newer versions of each component, most notably `node-sass`, so we can tap into libsass 3.0.2. This will be merged after we deploy Foundation 5.5.
