### PR TITLE
Updated package.json to include node v.0.12.0 compatible versions of node-sass and grunt-sass 

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "foundation-libsass-template",
   "version": "0.0.1",
   "devDependencies": {
-    "node-sass": "~1.2.3",
+    "node-sass": "~2.0.1",
     "grunt": "~0.4.5",
     "grunt-contrib-watch": "~0.6.1",
     "grunt-sass": "~0.17.0"

--- a/package.json
+++ b/package.json
@@ -5,6 +5,6 @@
     "node-sass": "~2.0.1",
     "grunt": "~0.4.5",
     "grunt-contrib-watch": "~0.6.1",
-    "grunt-sass": "~0.17.0"
+    "grunt-sass": "~0.18.0"
   }
 }


### PR DESCRIPTION
I'm new to using foundation, and ran into some issues with getting my project setup on my mac running node v.0.12.0.

Creating a new project with the foundation cli will fail if using node v.0.12.0 with the current package.json dependencies.

I tracked the problems back to grunt-sass v.0.17.0; it fails to register correctly under node v.0.12.0.

I updated the package.json to include node v.0.12.0 compatible versions of node-sass and grunt-sass.

I have tested the updated package.json with both node v.0.12.0 and v.0.10.33 and it completes without errors.
